### PR TITLE
Add Terraform learning examples and comprehensive guide

### DIFF
--- a/terraform/guide.md
+++ b/terraform/guide.md
@@ -1,0 +1,323 @@
+# Terraform Learning Guide (Practical + Memorization)
+
+This guide complements `learning.tf` with workflows, diagrams, best practices, and real-world scenarios.
+
+---
+
+## 1) Terraform Mental Model (Cheat Sheet)
+
+**Remember the flow:**
+`write -> init -> plan -> apply -> observe -> iterate -> destroy`
+
+**Key files**
+- `*.tf` — configuration
+- `terraform.tfstate` — current real-world state snapshot
+- `.terraform/` — provider plugins + module cache
+- `terraform.lock.hcl` — provider dependency lock file
+
+**Fast memory anchor:**
+- *Variables in, resources in the middle, outputs out.*
+
+---
+
+## 2) Core Blocks Summary (What/Why)
+
+- **terraform**: CLI settings, backend, required providers.
+- **provider**: credentials/region and API settings.
+- **variable**: input configuration.
+- **local**: computed constants.
+- **data**: read existing infra.
+- **resource**: manage infrastructure.
+- **module**: reusable bundle of resources.
+- **output**: expose values.
+
+---
+
+## 3) State: What It Is + How It Works
+
+**State definition (easy memory):**
+> *State is Terraform’s memory of what it created and how to map config to real resources.*
+
+### Diagram: State Relationship
+```
+   .tf config  -----> plan -----> apply
+       |                           |
+       |                           v
+       +---------------------- terraform.tfstate
+                                    |
+                                    v
+                                real resources
+```
+
+### Common State Commands
+- `terraform state list`
+- `terraform state show <addr>`
+- `terraform state mv <src> <dst>`
+- `terraform state rm <addr>`
+
+### Remote State (Recommended)
+**Use remote state for:** collaboration, locking, and recovery.
+
+Example remote backend: S3 + DynamoDB (locking).
+
+---
+
+## 4) Command Workflow (Step-by-step)
+
+### Step 1: Initialize
+```
+terraform init
+```
+- Downloads providers
+- Configures backend
+
+### Step 2: Validate and Format
+```
+terraform fmt
+terraform validate
+```
+
+### Step 3: Plan
+```
+terraform plan -out=tfplan
+```
+
+### Step 4: Apply
+```
+terraform apply tfplan
+```
+
+### Step 5: Observe
+```
+terraform show
+terraform output
+```
+
+### Step 6: Change / Destroy
+```
+terraform plan
+terraform apply
+terraform destroy
+```
+
+---
+
+## 5) Real-World Scenario (Simple Web App)
+
+**Goal:** Deploy a small web tier (SG + EC2) in dev, then prod.
+
+**Steps:**
+1. Create `learning.tf` with SG and instance.
+2. Configure backend to remote state.
+3. Provide variables via `dev.tfvars` and `prod.tfvars`.
+4. Use workspaces or multi-env directories (preferred).
+
+**Example apply:**
+```
+terraform plan -var-file=envs/dev.tfvars
+terraform apply -var-file=envs/dev.tfvars
+```
+
+---
+
+## 6) Multi-Environment Structure
+
+**Preferred structure (folders per env):**
+```
+terraform/
+  modules/
+    vpc/
+    app/
+  envs/
+    dev/
+      main.tf
+      dev.tfvars
+    stage/
+      main.tf
+      stage.tfvars
+    prod/
+      main.tf
+      prod.tfvars
+```
+
+### Why folder-per-env is best
+- Clear isolation of state
+- Safe changes without accidental cross-environment damage
+- Easier to reason about in CI/CD
+
+### Disadvantages of Workspaces
+- Easy to apply to wrong workspace
+- Harder to isolate state with different backends
+- Shared code tends to become complex with conditionals
+- Poor visibility in CI unless enforced carefully
+
+---
+
+## 7) Meta-Arguments Quick Guide
+
+- `count`: N copies, index-based (`count.index`)
+- `for_each`: map/set-based, stable keys (`each.key`, `each.value`)
+- `depends_on`: explicit dependency ordering
+- `lifecycle`: `create_before_destroy`, `prevent_destroy`, `ignore_changes`
+- `provider`: use provider aliases for multi-region
+
+### count vs for_each (simple memory)
+- **count** = *number-based*, use when identical resources.
+- **for_each** = *key-based*, use when objects vary or need stable identity.
+
+---
+
+## 8) Drift: What It Is + How to Detect
+
+**Drift definition:**
+> *Drift is when real infrastructure changes outside Terraform, making state differ from reality.*
+
+**Detect drift:**
+```
+terraform plan
+```
+It shows changes needed to match config.
+
+**Prevent drift:**
+- Avoid manual changes
+- Use read-only IAM for humans
+- Prefer automated pipelines
+
+---
+
+## 9) Secrets Handling (Best Practices)
+
+- Never hardcode secrets in `.tf` files.
+- Use environment variables (`TF_VAR_*`) or secret stores.
+- For AWS: use SSM Parameter Store or Secrets Manager.
+- Mark outputs as `sensitive = true`.
+
+Example output:
+```
+output "db_password" {
+  value     = var.db_password
+  sensitive = true
+}
+```
+
+---
+
+## 10) Validation and Testing
+
+- `terraform validate` for syntax and type checks.
+- Use `validation` blocks in variables.
+- Use `tflint` or `checkov` for policy checks (optional).
+
+---
+
+## 11) Import / Taint / Replace
+
+### Import
+Bring existing resources under Terraform management.
+```
+terraform import aws_instance.web i-0123456789abcdef0
+```
+
+### Taint (Deprecated, use replace)
+Marks a resource for recreation.
+```
+terraform apply -replace=aws_instance.web
+```
+
+### State Move (Refactor)
+```
+terraform state mv aws_instance.web aws_instance.web_old
+```
+
+---
+
+## 12) Common Issues + Fixes
+
+| Issue | Cause | Fix |
+|------|-------|-----|
+| Plan shows destroy/create | immutable change | Use `create_before_destroy` or accept replacement |
+| Provider auth error | bad creds | check env vars/credentials |
+| State lock error | stale lock | `terraform force-unlock <lock_id>` |
+| Drift detected | manual changes | re-apply or import |
+
+---
+
+## 13) Functions (Quick Reference)
+
+- `merge(map1, map2)`
+- `join(",", list)`
+- `toset(list)`
+- `length(list)`
+- `regex(pattern, string)`
+- `try(a, b, c)`
+- `coalesce(a, b)`
+- `lookup(map, key, default)`
+
+---
+
+## 14) Mind Map (Text)
+
+```
+Terraform
+├── Write
+│   ├── variables
+│   ├── locals
+│   ├── resources
+│   └── modules
+├── Init
+│   ├── providers
+│   └── backend
+├── Plan
+│   └── diff
+├── Apply
+│   └── state update
+├── Observe
+│   ├── outputs
+│   └── state show
+├── Maintain
+│   ├── drift detect
+│   └── refactor state
+└── Multi-env
+    ├── folders
+    └── workspaces (avoid)
+```
+
+---
+
+## 15) Easy-to-Remember Cheat Sheet
+
+**Rules of thumb:**
+- Use **modules** to reuse infra.
+- Use **for_each** when identity matters.
+- Keep **state remote** with locking.
+- Separate **dev/stage/prod** by folder.
+- Never commit secrets.
+
+**Mini checklist before apply:**
+- `terraform fmt`
+- `terraform validate`
+- `terraform plan`
+- Confirm workspace or env folder
+
+---
+
+## 16) Suggested File Layout (Beginner)
+
+```
+terraform/
+  learning.tf
+  envs/
+    dev.tfvars
+    stage.tfvars
+    prod.tfvars
+```
+
+---
+
+## 17) Definitions to Remember (Flash Cards)
+
+- **State:** Terraform’s memory of managed resources.
+- **Drift:** Real resources differ from state/config.
+- **Plan:** Execution preview.
+- **Module:** Reusable Terraform unit.
+- **Provider:** API plugin to manage resources.

--- a/terraform/learning.tf
+++ b/terraform/learning.tf
@@ -192,3 +192,8 @@ output "security_group_id" {
 // - for_each: create per map/set with stable keys
 // - lifecycle: customize create/replace/destroy behavior
 // - provider: override provider config per resource (alias)
+
+// QUICK MEMORY AID
+// Inputs -> Logic -> Outputs
+// Variables -> Locals/Data/Resources/Modules -> Outputs
+// State is the "memory" that connects this config to real infrastructure.

--- a/terraform/learning.tf
+++ b/terraform/learning.tf
@@ -1,0 +1,194 @@
+// Terraform learning file: core blocks, meta-arguments, and patterns.
+// This file is intentionally verbose and comment-heavy so you can learn by example.
+// NOTE: Some blocks are commented out or use placeholder values to avoid real changes.
+
+terraform {
+  // The terraform block configures settings for the CLI and backends.
+  // backend "s3" is commented to avoid accidental state changes.
+  // required_version ensures consistent CLI behavior.
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+
+  // backend "s3" {
+  //   bucket         = "my-tf-state"
+  //   key            = "envs/dev/terraform.tfstate"
+  //   region         = "us-east-1"
+  //   dynamodb_table = "my-tf-locks" // state locking
+  //   encrypt        = true
+  // }
+}
+
+provider "aws" {
+  // Provider config uses variables and locals for flexibility.
+  region = var.aws_region
+
+  default_tags {
+    tags = local.common_tags
+  }
+}
+
+// VARIABLES -----------------------------------------------------------------
+// Input variables let you parameterize your configuration.
+variable "aws_region" {
+  description = "AWS region for resources"
+  type        = string
+  default     = "us-east-1"
+  validation {
+    condition     = can(regex("^[a-z]{2}-[a-z]+-\d$", var.aws_region))
+    error_message = "Region must look like us-east-1."
+  }
+}
+
+variable "environment" {
+  description = "Deployment environment (dev/stage/prod)"
+  type        = string
+}
+
+variable "instance_count" {
+  description = "Number of EC2 instances to create"
+  type        = number
+  default     = 2
+  validation {
+    condition     = var.instance_count >= 1 && var.instance_count <= 10
+    error_message = "instance_count must be between 1 and 10."
+  }
+}
+
+variable "subnet_ids" {
+  description = "List of subnet IDs for instances"
+  type        = list(string)
+}
+
+// LOCALS ---------------------------------------------------------------------
+// Locals are computed values used to DRY up your config.
+locals {
+  name_prefix = "${var.environment}-web"
+  common_tags = {
+    project     = "learning"
+    environment = var.environment
+    managed_by  = "terraform"
+  }
+}
+
+// DATA SOURCES ---------------------------------------------------------------
+// Data sources read existing infrastructure.
+// Example: find latest Amazon Linux 2 AMI.
+data "aws_ami" "amzn2" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+// RESOURCES ------------------------------------------------------------------
+// Resources create or manage infrastructure.
+resource "aws_security_group" "web" {
+  name        = "${local.name_prefix}-sg"
+  description = "Allow HTTP/HTTPS"
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = local.common_tags
+}
+
+resource "aws_instance" "web" {
+  // Meta-arguments:
+  // count -> creates N copies
+  count = var.instance_count
+
+  // for_each is an alternative when you want stable keys
+  // for_each = toset(var.subnet_ids)
+
+  ami           = data.aws_ami.amzn2.id
+  instance_type = "t3.micro"
+
+  // Example for count: distribute across subnets by index
+  subnet_id = var.subnet_ids[count.index % length(var.subnet_ids)]
+
+  vpc_security_group_ids = [aws_security_group.web.id]
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-${count.index + 1}"
+  })
+
+  // lifecycle meta-argument controls changes.
+  lifecycle {
+    create_before_destroy = true
+    prevent_destroy       = false
+    ignore_changes        = [tags["LastUpdated"]]
+  }
+
+  // depends_on explicitly orders resources when needed.
+  depends_on = [aws_security_group.web]
+}
+
+// NULL RESOURCE --------------------------------------------------------------
+// null_resource can run provisioners or trigger actions.
+// Use sparingly; prefer native resources or external pipelines.
+resource "null_resource" "notify" {
+  triggers = {
+    instance_ids = join(",", aws_instance.web[*].id)
+  }
+
+  // local-exec provisioner example
+  provisioner "local-exec" {
+    command = "echo Instances changed: ${self.triggers.instance_ids}"
+  }
+}
+
+// MODULES --------------------------------------------------------------------
+// Modules are reusable bundles of Terraform config.
+// Example of calling a module (commented to avoid external dependency).
+// module "vpc" {
+//   source  = "terraform-aws-modules/vpc/aws"
+//   version = "5.1.0"
+//   name    = "${local.name_prefix}-vpc"
+//   cidr    = "10.0.0.0/16"
+// }
+
+// OUTPUTS --------------------------------------------------------------------
+// Outputs expose values after apply for other modules or users.
+output "instance_ids" {
+  description = "IDs of the created instances"
+  value       = aws_instance.web[*].id
+}
+
+output "security_group_id" {
+  description = "Security group ID"
+  value       = aws_security_group.web.id
+}
+
+// META-ARGUMENTS (summary)
+// - depends_on: explicit dependency
+// - count: create N instances, indexed by count.index
+// - for_each: create per map/set with stable keys
+// - lifecycle: customize create/replace/destroy behavior
+// - provider: override provider config per resource (alias)


### PR DESCRIPTION
### Motivation
- Provide a single, comment-rich Terraform example that demonstrates core blocks, meta-arguments, patterns, and common usage to help learners remember structure in one file. 
- Provide a companion guide with diagrams, command workflows, state handling, multi-environment guidance, secrets handling, and a mind-map/cheat-sheet for practical memorization and real-world scenarios.

### Description
- Add `terraform/learning.tf` containing a heavily commented Terraform configuration that demonstrates the `terraform` block, `provider`, `variable`, `local`, `data`, `resource`, `null_resource`, `module` examples, `output` blocks, and meta-arguments like `count`, `for_each`, `depends_on`, and `lifecycle` in-context. 
- Add `terraform/guide.md` containing step-by-step workflows (`terraform init`, `plan`, `apply`, etc.), state explanations and commands (`terraform state list`, `terraform state mv`, ...), multi-environment folder recommendations and workspace caveats, secrets best practices, import/replace guidance, drift detection, functions reference, and a textual mind map and cheat sheet. 
- Files include practical examples and safety notes (many production-affecting blocks are commented out) so the content is safe to read and adapt.

### Testing
- No automated tests were executed because these are documentation and example configuration files only. 
- Basic repository checks were performed to add and create the new files but no `terraform` commands or validation were run against live infrastructure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982103a79388324a1cc746e0a0e1d2d)