### PR TITLE
Reorder learning path to on‑prem → microservices → containers and add TODO chapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A structured path that starts from how computers work (CPU, memory, storage) and builds toward DevOps, platform engineering, and cloud tooling. This README is a **skeleton** for the future reorganization of the repository and for the GitHub Pages site.
 
+## 🧭 Start Here
+- [Roadmap (visual sketch + ordered path)](./roadmap.md)
+- [Navigation page (jump to any topic/file)](./index.md)
+
 ## ✅ Goals
 - Teach DevOps from the ground up: hardware → OS → networking → programming → systems → cloud → platform tools.
 - Provide a clear learning path with **short lessons**, **labs**, and **diagrams**.

--- a/index.md
+++ b/index.md
@@ -3,22 +3,109 @@
 Welcome to the DevOps learning path — from how computers start (CPU, memory, boot process) to cloud platforms and DevOps tooling.
 
 ## Start Here
-- [Roadmap & Structure](./README.md)
+- [Roadmap (visual sketch + ordering)](./roadmap.md)
+- [Repository overview](./README.md)
 
-## Learning Sections (Planned)
-- Foundations (CPU, memory, storage, boot process)
-- Networking (TCP/IP, DNS, HTTP, TLS)
-- Linux & OS basics
-- Programming for Ops (Python)
-- Git & collaboration
-- Databases & data systems
-- Servers & web infrastructure
-- Containers & Docker
-- Kubernetes & orchestration
-- CI/CD pipelines
-- Observability (logs/metrics/traces)
-- Infrastructure as Code
-- Cloud fundamentals
-- Platform engineering
-- Security & DevSecOps
-- Projects & labs
+## Topic Navigation (Ordered Flow)
+
+### 1) Basics
+- [Test](./Basics/Test)
+
+### 2) CS
+- [Database](./CS/Database)
+- [Disk](./CS/Disk)
+- [Machines to computers](./CS/Machines%20to%20computers)
+- [Virtual_Memory](./CS/Virtual_Memory)
+- [messaging](./CS/messaging)
+
+### 3) basics (expanded)
+
+#### 3.1) Foundations & Platforms
+- [1.AgileScrumDevops.md](./basics/1.AgileScrumDevops.md)
+- [2.Platformengineering.md](./basics/2.Platformengineering.md)
+- [interview.md](./basics/interview.md)
+- [test.md](./basics/test.md)
+
+#### 3.2) Linux & Containers
+- [3.0.LinuxOSIntro.md](./basics/3.0.LinuxOSIntro.md)
+- [3.1.linux_container_isolation_notes.md](./basics/3.1.linux_container_isolation_notes.md)
+- [3.2.0.linux_processes_signals_zombies_oom_docker_k8s.md](./basics/3.2.0.linux_processes_signals_zombies_oom_docker_k8s.md)
+- [3.2.OverlayFS.md](./basics/3.2.OverlayFS.md)
+- [3.3.privileged_containers_threat_model.md](./basics/3.3.privileged_containers_threat_model.md)
+- [3.4.linux_cgroups_cpu_memory_deep_dive.md](./basics/3.4.linux_cgroups_cpu_memory_deep_dive.md)
+- [3.5.linux c group 2.md](./basics/3.5.linux%20c%20group%202.md)
+- [3.6.cpuvs memory](./basics/3.6.cpuvs%20memory)
+- [3.7. Disks VS filesystems.md](./basics/3.7.%20Disks%20VS%20filesystems.md)
+- [3.7.0.filesystem_exists_or_not_and_how_bytes_become_files.md](./basics/3.7.0.filesystem_exists_or_not_and_how_bytes_become_files.md)
+- [3.7.1.storage_from_disk_to_filesystem_onprem.md](./basics/3.7.1.storage_from_disk_to_filesystem_onprem.md)
+- [3.docker.md](./basics/3.docker.md)
+
+#### 3.3) Databases & Reliability
+- [4.0.databases_for_platform_engineers_foundations.md](./basics/4.0.databases_for_platform_engineers_foundations.md)
+- [4.1.part_2_platform_engineering_databases_high_availability_and_operations.md](./basics/4.1.part_2_platform_engineering_databases_high_availability_and_operations.md)
+- [4.2.databases_and_redis_in_production_platform_engineer_guide.md](./basics/4.2.databases_and_redis_in_production_platform_engineer_guide.md)
+- [4.3postgre_sql_on_kubernetes_vs_azure_managed_postgres_platform_guide.md](./basics/4.3postgre_sql_on_kubernetes_vs_azure_managed_postgres_platform_guide.md)
+
+#### 3.4) Kubernetes, CI/CD, and Misc
+- [5.k8s](./basics/5.k8s)
+- [6.0.0.CI.md](./basics/6.0.0.CI.md)
+- [CD](./basics/CD/)
+- [CI](./basics/CI/)
+- [all in one](./basics/all%20in%20one)
+- [import argparse.py](./basics/import%20argparse.py)
+
+#### 3.5) Images
+- [image-1.png](./basics/image-1.png)
+- [image.png](./basics/image.png)
+
+### 4) On-Prem Story & Migration
+- [On-prem era story (TODO)](./todo/01-onprem-story.todo.md)
+- [Why on-prem had issues (TODO)](./todo/02-onprem-issues.todo.md)
+- [MigrationMM.md](./onprem/MigrationMM.md)
+
+### 5) Monolith → Microservices
+- [Monolith to microservices (TODO)](./todo/03-monolith-to-microservices.todo.md)
+- [microservice.md](./Microservices/microservice.md)
+
+### 6) Containers & Docker
+- [Containers and Docker adoption (TODO)](./todo/04-containers-docker.todo.md)
+- [3.docker.md](./basics/3.docker.md)
+
+### 7) Kubernetes
+- [K8s.md](./K8s/K8s.md)
+- [helm.md](./K8s/helm.md)
+
+### 8) Programming & Scripting
+- [01_what_is_import.md](./Python/01_what_is_import.md)
+- [02_variables_and_types.md](./Python/02_variables_and_types.md)
+- [03_functions_basics.md](./Python/03_functions_basics.md)
+- [04_modules_json_yaml.md](./Python/04_modules_json_yaml.md)
+- [05_everything_is_object.md](./Python/05_everything_is_object.md)
+- [06_mutability_memory.md](./Python/06_mutability_memory.md)
+- [07_logging_exploration.md](./Python/07_logging_exploration.md)
+- [08_azure_devops_modules.md](./Python/08_azure_devops_modules.md)
+- [09_python_modules_and_packages.md](./Python/09_python_modules_and_packages.md)
+- [10_exception_handling.md](./Python/10_exception_handling.md)
+- [11_cli_click.md](./Python/11_cli_click.md)
+- [12_devops_web_automation.md](./Python/12_devops_web_automation.md)
+
+### 9) Git & Version Control
+- [Version control before Git (TODO)](./todo/05-version-control-before-git.todo.md)
+- [git-visualize.md](./Git/git-visualize.md)
+- [git.md](./Git/git.md)
+
+### 10) Databases
+- [comparisiontable.md](./DB/comparisiontable.md)
+- [statefulset-simplified.md](./DB/statefulset-simplified.md)
+- [statefulset.md](./DB/statefulset.md)
+
+### 11) Server
+- [WebServer/Ngnix.md](./Server/WebServer/Ngnix.md)
+
+### 12) cloud-networking
+- [Networking.html](./cloud-networking/Networking.html)
+- [Networking2.html](./cloud-networking/Networking2.html)
+
+### 13) Notes & Backlog
+- [progress md](./progress%20md)
+- [test.md](./test.md)

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,0 +1,126 @@
+# DevOps From Scratch — Roadmap
+
+This page gives you a **big-picture sketch** of the journey (from how computers started to modern platform engineering) and a **single ordered path** through the existing topics.
+
+## 1) Big-Picture Sketch (Learning Journey)
+
+```mermaid
+flowchart LR
+    A[How computers started
+- Machines → computers
+- CPU, memory, storage] --> B[Operating Systems
+- processes, filesystems]
+    B --> C[Networking
+- TCP/IP, DNS, HTTP/TLS]
+    C --> D[Programming for Ops
+- Python + automation]
+    D --> E[Systems & Data
+- servers, databases]
+    E --> F[Containers & Orchestration
+- Docker, Kubernetes]
+    F --> G[CI/CD & Delivery]
+    G --> H[Cloud & Platform Engineering
+- Azure, infra, reliability]
+```
+
+## 2) Ordered Path (Current Topics, No Reordering)
+
+Follow the topics below in the exact order they exist today. This preserves your current structure while giving a clean navigation path.
+
+1. [Basics](./Basics/)
+2. [CS](./CS/)
+3. [basics](./basics/)
+4. [On-Prem Story & Migration](./todo/01-onprem-story.todo.md)
+5. [Monolith → Microservices](./todo/03-monolith-to-microservices.todo.md)
+6. [Containers & Docker](./todo/04-containers-docker.todo.md)
+7. [Kubernetes](./K8s/)
+8. [Programming & Scripting](./Python/)
+9. [Git & Version Control](./todo/05-version-control-before-git.todo.md)
+10. [Databases](./DB/)
+11. [Server](./Server/)
+12. [cloud-networking](./cloud-networking/)
+13. [Notes & Backlog](./progress%20md)
+
+## 3) How to Use This Roadmap
+
+- **Start with the ordered path** above and go top-to-bottom.
+- Use the **Topic Navigation** section on the homepage to jump directly to any file.
+- Capture new learnings in the **Notes & Backlog** file, then later migrate them into the proper folder when you refine structure.
+
+## 4) Recommended Missing Topics (TODO)
+
+Add these as you expand the repo. They are grouped from fundamentals to advanced topics and tools that are common in DevOps/platform roles.
+
+### 4.1) Foundations (TODO)
+- Computer history (from early machines to modern CPUs)
+- Number systems, binary/hex, data encoding
+- CPU architecture, memory hierarchy, storage basics
+- Boot process (BIOS/UEFI), firmware, and kernel initialization
+- OS concepts: processes, threads, scheduling, syscalls
+- Filesystems internals, permissions, and storage layers
+
+### 4.2) Networking (TODO)
+- OSI model & TCP/IP deep dive
+- L2/L3: ARP, VLANs, routing, BGP basics
+- L4/L7: load balancing, reverse proxies
+- DNS, DHCP, NAT, MTU, and troubleshooting
+- TLS/SSL, certificates, and mTLS
+
+### 4.3) Application Layers & Failures (TODO)
+- App architecture basics (monoliths vs services)
+- Application layers (UI, API, service, data)
+- Failure modes: timeouts, retries, thundering herd
+- Performance tuning: caching, queues, backpressure
+- Incident response patterns and postmortems
+
+### 4.4) Linux & Systems (TODO)
+- Systemd, logging, journal, and process management
+- Resource isolation (cgroups, namespaces)
+- Kernel tuning and performance tools
+- Storage troubleshooting (IOPS, latency, RAID)
+
+### 4.5) Databases & Data Systems (TODO)
+- SQL vs NoSQL tradeoffs
+- Replication, backups, PITR, HA strategies
+- Data consistency, transactions, locks, indexes
+- Managed vs self-hosted databases
+
+### 4.6) Containers & Orchestration (TODO)
+- Container lifecycle, images, registries
+- Kubernetes workloads, networking, storage
+- Service meshes, gateways, and ingress patterns
+- Scaling: HPA, VPA, cluster autoscaling
+
+### 4.7) CI/CD & Release Engineering (TODO)
+- Pipeline design, environments, and approvals
+- Build artifacts, SBOMs, and provenance
+- GitOps workflows and promotion strategies
+
+### 4.8) Infrastructure as Code (TODO)
+- Terraform state and module design
+- Policy as code (OPA, Azure Policy)
+- Configuration management (Ansible, Chef)
+
+### 4.9) Cloud & Platform (TODO)
+- Azure core services (compute, storage, network)
+- IAM, RBAC, and identity federation
+- Landing zones, hub/spoke networking
+- Cost management and FinOps
+
+### 4.10) Observability & SRE (TODO)
+- Logs, metrics, traces (golden signals)
+- SLIs/SLOs, error budgets
+- Alerting design and noise reduction
+
+### 4.11) Security & Compliance (TODO)
+- Secrets management (Vault, Key Vault)
+- Container/image security (scanning, signing)
+- Threat modeling and secure defaults
+- Compliance basics (SOC2, ISO, PCI)
+
+### 4.12) Tools to Cover (TODO)
+- GitHub Actions / Azure DevOps / GitLab CI
+- Docker, Helm, Kustomize
+- Terraform, Ansible, Packer
+- Prometheus, Grafana, Loki, OpenTelemetry
+- Argo CD / Flux, Backstage

--- a/todo/01-onprem-story.todo.md
+++ b/todo/01-onprem-story.todo.md
@@ -1,0 +1,14 @@
+# TODO: On-Prem Era Story (Chapters + Flow)
+
+## Goal
+Document how traditional on-prem infrastructure worked before cloud adoption.
+
+## What to cover
+- Typical on-prem architecture (data center, racks, networking, storage)
+- Procurement and provisioning timelines
+- Operations flow (ticketing, change windows, maintenance)
+- Real-world examples and diagrams
+- Pain points that motivated change
+
+## Deliverable
+A chapter-style narrative with at least one diagram and a short case study.

--- a/todo/02-onprem-issues.todo.md
+++ b/todo/02-onprem-issues.todo.md
@@ -1,0 +1,14 @@
+# TODO: Why On-Prem Had Issues
+
+## Goal
+Explain why on-prem models struggled at scale and drove the shift to newer architectures.
+
+## What to cover
+- Scaling limits and capacity planning
+- Long lead times and hardware constraints
+- Reliability challenges and DR complexity
+- Cost visibility and underutilization
+- Security/compliance and patching overhead
+
+## Deliverable
+A concise analysis with a comparison table: on-prem vs cloud.

--- a/todo/03-monolith-to-microservices.todo.md
+++ b/todo/03-monolith-to-microservices.todo.md
@@ -1,0 +1,13 @@
+# TODO: Monolith → Microservices
+
+## Goal
+Describe the evolution from monolithic applications to microservices and the tradeoffs.
+
+## What to cover
+- Monolith characteristics and benefits
+- Drivers for microservices (scale, ownership, release velocity)
+- Common failure modes and operational complexity
+- Example migration approach (strangler pattern)
+
+## Deliverable
+A migration narrative plus a pros/cons matrix.

--- a/todo/04-containers-docker.todo.md
+++ b/todo/04-containers-docker.todo.md
@@ -1,0 +1,13 @@
+# TODO: Containers and Docker Adoption
+
+## Goal
+Explain why containers emerged, and how Docker changed packaging and deployment.
+
+## What to cover
+- Process isolation vs VMs
+- Image layering, registries, and distribution
+- Developer workflow improvements
+- Common pitfalls and best practices
+
+## Deliverable
+A practical guide with a simple container lifecycle diagram.

--- a/todo/05-version-control-before-git.todo.md
+++ b/todo/05-version-control-before-git.todo.md
@@ -1,0 +1,12 @@
+# TODO: Version Control Before Git
+
+## Goal
+Document how teams managed code and collaboration before Git became standard.
+
+## What to cover
+- Centralized VCS (SVN, Perforce) workflows
+- Branching/merging limitations and pain points
+- Why Git’s model solved key issues
+
+## Deliverable
+A short history section + comparison table.


### PR DESCRIPTION
### Motivation
- Reorganize the repo navigation to follow a logical historical and pedagogical flow (on‑prem → monolith → microservices → containers → Kubernetes → programming → version control) so readers encounter topics in an intuitive order. 
- Surface missing narrative content as explicit TODO placeholders so authors know what chapters to write and what each should cover.

### Description
- Update the landing navigation in `index.md` to the ordered flow and place programming and Git under the appropriate sections.  
- Add a new `roadmap.md` (including a mermaid big‑picture sketch) that documents the ordered path and recommended missing topics.  
- Add five TODO placeholder files under `todo/` (`01-onprem-story.todo.md`, `02-onprem-issues.todo.md`, `03-monolith-to-microservices.todo.md`, `04-containers-docker.todo.md`, `05-version-control-before-git.todo.md`) with clear goals, coverage bullets, and deliverables.  
- Small README improvement: add quick links to the `roadmap.md` and `index.md` start pages.

### Testing
- No automated tests were executed because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989491d6c3c8324afbee3dc5a47840e)