### PR TITLE
Add modular AKS Terraform stack with ACR, Log Analytics, VNet, and Traffic Manager

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,216 +1,64 @@
-# =============================================================================
-# OPENTOFU/TERRAFORM - Azure Container Apps Deployment
-# =============================================================================
-# Deploys: API + UI + Container Registry
-# =============================================================================
-
 terraform {
   required_version = ">= 1.0.0"
-  
+
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "~> 3.80"
     }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
   }
 }
 
-# -----------------------------------------------------------------------------
-# Provider Configuration
-# -----------------------------------------------------------------------------
 provider "azurerm" {
   features {}
-  subscription_id = var.subscription_id
 }
 
-# -----------------------------------------------------------------------------
-# Resource Group
-# -----------------------------------------------------------------------------
-resource "azurerm_resource_group" "main" {
-  name     = "rg-${var.app_name}-${var.environment}"
+module "rg" {
+  source   = "./modules/resource_group"
+  name     = var.resource_group_name
   location = var.location
-  
-  tags = {
-    environment = var.environment
-    app         = var.app_name
-  }
 }
 
-# -----------------------------------------------------------------------------
-# Container Registry (to store Docker images)
-# -----------------------------------------------------------------------------
-resource "azurerm_container_registry" "main" {
-  name                = replace("acr${var.app_name}${var.environment}", "-", "")
-  resource_group_name = azurerm_resource_group.main.name
-  location            = azurerm_resource_group.main.location
-  sku                 = "Basic"
-  admin_enabled       = false  # Using Managed Identity instead
-  
-  tags = {
-    environment = var.environment
-  }
+module "vnet" {
+  source              = "./modules/vnet"
+  resource_group_name = module.rg.name
+  location            = module.rg.location
+  vnet_name           = var.vnet_name
+  subnet_name         = var.subnet_name
 }
 
-# -----------------------------------------------------------------------------
-# User Assigned Managed Identity (for ACR pull)
-# -----------------------------------------------------------------------------
-resource "azurerm_user_assigned_identity" "acr_pull" {
-  name                = "id-${var.app_name}-acr-pull"
-  resource_group_name = azurerm_resource_group.main.name
-  location            = azurerm_resource_group.main.location
-  
-  tags = {
-    environment = var.environment
-  }
+module "log_analytics" {
+  source              = "./modules/log_analytics"
+  resource_group_name = module.rg.name
+  location            = module.rg.location
+  workspace_name      = var.log_workspace_name
 }
 
-# -----------------------------------------------------------------------------
-# Role Assignment - Give MI permission to pull from ACR
-# -----------------------------------------------------------------------------
-resource "azurerm_role_assignment" "acr_pull" {
-  scope                = azurerm_container_registry.main.id
-  role_definition_name = "AcrPull"
-  principal_id         = azurerm_user_assigned_identity.acr_pull.principal_id
+module "acr" {
+  source              = "./modules/acr"
+  resource_group_name = module.rg.name
+  location            = module.rg.location
+  acr_name            = var.acr_name
 }
 
-# -----------------------------------------------------------------------------
-# Log Analytics (for Container Apps logs)
-# -----------------------------------------------------------------------------
-resource "azurerm_log_analytics_workspace" "main" {
-  name                = "log-${var.app_name}-${var.environment}"
-  resource_group_name = azurerm_resource_group.main.name
-  location            = azurerm_resource_group.main.location
-  sku                 = "PerGB2018"
-  retention_in_days   = 30
+module "aks" {
+  source              = "./modules/aks"
+  resource_group_name = module.rg.name
+  location            = module.rg.location
+  cluster_name        = var.aks_name
+  subnet_id           = module.vnet.subnet_id
+  log_workspace_id    = module.log_analytics.workspace_id
+  acr_id              = module.acr.acr_id
 }
 
-# -----------------------------------------------------------------------------
-# Container Apps Environment
-# -----------------------------------------------------------------------------
-resource "azurerm_container_app_environment" "main" {
-  name                       = "cae-${var.app_name}-${var.environment}"
-  resource_group_name        = azurerm_resource_group.main.name
-  location                   = azurerm_resource_group.main.location
-  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
-  
-  tags = {
-    environment = var.environment
-  }
-}
-
-# -----------------------------------------------------------------------------
-# Container App - API (Backend)
-# -----------------------------------------------------------------------------
-resource "azurerm_container_app" "api" {
-  name                         = "ca-${var.app_name}-api"
-  container_app_environment_id = azurerm_container_app_environment.main.id
-  resource_group_name          = azurerm_resource_group.main.name
-  revision_mode                = "Single"
-  
-  # Use Managed Identity for ACR authentication
-  identity {
-    type         = "UserAssigned"
-    identity_ids = [azurerm_user_assigned_identity.acr_pull.id]
-  }
-  
-  # Registry with Managed Identity (no password needed!)
-  registry {
-    server   = azurerm_container_registry.main.login_server
-    identity = azurerm_user_assigned_identity.acr_pull.id
-  }
-  
-  template {
-    container {
-      name   = "api"
-      image  = "${azurerm_container_registry.main.login_server}/${var.app_name}-api:${var.image_tag}"
-      cpu    = 0.25
-      memory = "0.5Gi"
-      
-      env {
-        name  = "ENV"
-        value = var.environment
-      }
-    }
-    
-    # Scale settings
-    min_replicas = 0  # Scale to zero when idle
-    max_replicas = 3
-  }
-  
-  ingress {
-    external_enabled = true
-    target_port      = 8000
-    transport        = "http"
-    
-    traffic_weight {
-      percentage      = 100
-      latest_revision = true
-    }
-  }
-  
-  tags = {
-    environment = var.environment
-    component   = "api"
-  }
-  
-  depends_on = [azurerm_role_assignment.acr_pull]
-}
-
-# -----------------------------------------------------------------------------
-# Container App - UI (Frontend)
-# -----------------------------------------------------------------------------
-resource "azurerm_container_app" "ui" {
-  name                         = "ca-${var.app_name}-ui"
-  container_app_environment_id = azurerm_container_app_environment.main.id
-  resource_group_name          = azurerm_resource_group.main.name
-  revision_mode                = "Single"
-  
-  # Use Managed Identity for ACR authentication
-  identity {
-    type         = "UserAssigned"
-    identity_ids = [azurerm_user_assigned_identity.acr_pull.id]
-  }
-  
-  # Registry with Managed Identity (no password needed!)
-  registry {
-    server   = azurerm_container_registry.main.login_server
-    identity = azurerm_user_assigned_identity.acr_pull.id
-  }
-  
-  template {
-    container {
-      name   = "ui"
-      image  = "${azurerm_container_registry.main.login_server}/${var.app_name}-ui:${var.image_tag}"
-      cpu    = 0.25
-      memory = "0.5Gi"
-      
-      # UI connects to API using its FQDN (public URL)
-      env {
-        name  = "API_URL"
-        value = "https://${azurerm_container_app.api.ingress[0].fqdn}"
-      }
-    }
-    
-    min_replicas = 0
-    max_replicas = 3
-  }
-  
-  ingress {
-    external_enabled = true
-    target_port      = 8501
-    transport        = "http"
-    
-    traffic_weight {
-      percentage      = 100
-      latest_revision = true
-    }
-  }
-  
-  tags = {
-    environment = var.environment
-    component   = "ui"
-  }
-  
-  # UI depends on API being created first (to get the URL)
-  depends_on = [azurerm_container_app.api, azurerm_role_assignment.acr_pull]
+module "traffic_manager" {
+  source              = "./modules/traffic_manager"
+  resource_group_name = module.rg.name
+  tm_name             = var.tm_name
+  target_dns          = module.aks.aks_fqdn
 }

--- a/terraform/modules/acr/main.tf
+++ b/terraform/modules/acr/main.tf
@@ -1,0 +1,17 @@
+resource "random_integer" "acr_suffix" {
+  min = 10000
+  max = 99999
+}
+
+locals {
+  sanitized_acr_name = lower(replace(var.acr_name, "-", ""))
+  unique_acr_name    = "${local.sanitized_acr_name}${random_integer.acr_suffix.result}"
+}
+
+resource "azurerm_container_registry" "acr" {
+  name                = local.unique_acr_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  sku                 = "Basic"
+  admin_enabled       = false
+}

--- a/terraform/modules/acr/outputs.tf
+++ b/terraform/modules/acr/outputs.tf
@@ -1,0 +1,7 @@
+output "acr_id" {
+  value = azurerm_container_registry.acr.id
+}
+
+output "acr_name" {
+  value = azurerm_container_registry.acr.name
+}

--- a/terraform/modules/acr/variables.tf
+++ b/terraform/modules/acr/variables.tf
@@ -1,0 +1,11 @@
+variable "resource_group_name" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "acr_name" {
+  type = string
+}

--- a/terraform/modules/aks/main.tf
+++ b/terraform/modules/aks/main.tf
@@ -1,0 +1,27 @@
+resource "azurerm_kubernetes_cluster" "aks" {
+  name                = var.cluster_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  dns_prefix          = var.cluster_name
+
+  default_node_pool {
+    name           = "nodepool"
+    node_count     = 1
+    vm_size        = "Standard_DS2_v2"
+    vnet_subnet_id = var.subnet_id
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  oms_agent {
+    log_analytics_workspace_id = var.log_workspace_id
+  }
+}
+
+resource "azurerm_role_assignment" "acr_attach" {
+  principal_id         = azurerm_kubernetes_cluster.aks.kubelet_identity[0].object_id
+  role_definition_name = "AcrPull"
+  scope                = var.acr_id
+}

--- a/terraform/modules/aks/outputs.tf
+++ b/terraform/modules/aks/outputs.tf
@@ -1,0 +1,3 @@
+output "aks_fqdn" {
+  value = azurerm_kubernetes_cluster.aks.fqdn
+}

--- a/terraform/modules/aks/variables.tf
+++ b/terraform/modules/aks/variables.tf
@@ -1,0 +1,23 @@
+variable "resource_group_name" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "cluster_name" {
+  type = string
+}
+
+variable "subnet_id" {
+  type = string
+}
+
+variable "log_workspace_id" {
+  type = string
+}
+
+variable "acr_id" {
+  type = string
+}

--- a/terraform/modules/log_analytics/main.tf
+++ b/terraform/modules/log_analytics/main.tf
@@ -1,0 +1,7 @@
+resource "azurerm_log_analytics_workspace" "law" {
+  name                = var.workspace_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}

--- a/terraform/modules/log_analytics/outputs.tf
+++ b/terraform/modules/log_analytics/outputs.tf
@@ -1,0 +1,3 @@
+output "workspace_id" {
+  value = azurerm_log_analytics_workspace.law.id
+}

--- a/terraform/modules/log_analytics/variables.tf
+++ b/terraform/modules/log_analytics/variables.tf
@@ -1,0 +1,11 @@
+variable "resource_group_name" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "workspace_name" {
+  type = string
+}

--- a/terraform/modules/resource_group/main.tf
+++ b/terraform/modules/resource_group/main.tf
@@ -1,0 +1,4 @@
+resource "azurerm_resource_group" "rg" {
+  name     = var.name
+  location = var.location
+}

--- a/terraform/modules/resource_group/outputs.tf
+++ b/terraform/modules/resource_group/outputs.tf
@@ -1,0 +1,7 @@
+output "name" {
+  value = azurerm_resource_group.rg.name
+}
+
+output "location" {
+  value = azurerm_resource_group.rg.location
+}

--- a/terraform/modules/resource_group/variables.tf
+++ b/terraform/modules/resource_group/variables.tf
@@ -1,0 +1,7 @@
+variable "name" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}

--- a/terraform/modules/traffic_manager/main.tf
+++ b/terraform/modules/traffic_manager/main.tf
@@ -1,0 +1,24 @@
+resource "azurerm_traffic_manager_profile" "tm" {
+  name                   = var.tm_name
+  resource_group_name    = var.resource_group_name
+  traffic_routing_method = "Priority"
+
+  dns_config {
+    relative_name = var.tm_name
+    ttl           = 60
+  }
+
+  monitor_config {
+    protocol = "HTTPS"
+    port     = 443
+    path     = "/"
+  }
+}
+
+resource "azurerm_traffic_manager_endpoint" "endpoint" {
+  name       = "aks-endpoint"
+  profile_id = azurerm_traffic_manager_profile.tm.id
+  type       = "externalEndpoints"
+  target     = var.target_dns
+  priority   = 1
+}

--- a/terraform/modules/traffic_manager/outputs.tf
+++ b/terraform/modules/traffic_manager/outputs.tf
@@ -1,0 +1,3 @@
+output "fqdn" {
+  value = azurerm_traffic_manager_profile.tm.fqdn
+}

--- a/terraform/modules/traffic_manager/variables.tf
+++ b/terraform/modules/traffic_manager/variables.tf
@@ -1,0 +1,11 @@
+variable "resource_group_name" {
+  type = string
+}
+
+variable "tm_name" {
+  type = string
+}
+
+variable "target_dns" {
+  type = string
+}

--- a/terraform/modules/vnet/main.tf
+++ b/terraform/modules/vnet/main.tf
@@ -1,0 +1,13 @@
+resource "azurerm_virtual_network" "vnet" {
+  name                = var.vnet_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "subnet" {
+  name                 = var.subnet_name
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = ["10.0.1.0/24"]
+}

--- a/terraform/modules/vnet/outputs.tf
+++ b/terraform/modules/vnet/outputs.tf
@@ -1,0 +1,3 @@
+output "subnet_id" {
+  value = azurerm_subnet.subnet.id
+}

--- a/terraform/modules/vnet/variables.tf
+++ b/terraform/modules/vnet/variables.tf
@@ -1,0 +1,15 @@
+variable "resource_group_name" {
+  type = string
+}
+
+variable "location" {
+  type = string
+}
+
+variable "vnet_name" {
+  type = string
+}
+
+variable "subnet_name" {
+  type = string
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,44 +1,27 @@
-# =============================================================================
-# OUTPUTS - URLs and information after deployment
-# =============================================================================
-
 output "resource_group_name" {
-  description = "Name of the resource group"
-  value       = azurerm_resource_group.main.name
+  value = module.rg.name
 }
 
-output "acr_login_server" {
-  description = "Azure Container Registry login server"
-  value       = azurerm_container_registry.main.login_server
+output "vnet_subnet_id" {
+  value = module.vnet.subnet_id
 }
 
-output "managed_identity_id" {
-  description = "Managed Identity used for ACR pull"
-  value       = azurerm_user_assigned_identity.acr_pull.id
+output "acr_id" {
+  value = module.acr.acr_id
 }
 
-output "managed_identity_client_id" {
-  description = "Managed Identity client ID"
-  value       = azurerm_user_assigned_identity.acr_pull.client_id
+output "acr_name" {
+  value = module.acr.acr_name
 }
 
-output "api_url" {
-  description = "URL of the API (FastAPI)"
-  value       = "https://${azurerm_container_app.api.ingress[0].fqdn}"
+output "aks_fqdn" {
+  value = module.aks.aks_fqdn
 }
 
-output "api_docs_url" {
-  description = "URL of the API documentation"
-  value       = "https://${azurerm_container_app.api.ingress[0].fqdn}/docs"
+output "log_analytics_workspace_id" {
+  value = module.log_analytics.workspace_id
 }
 
-output "ui_url" {
-  description = "URL of the UI (Streamlit)"
-  value       = "https://${azurerm_container_app.ui.ingress[0].fqdn}"
-}
-
-# Quick command to login to ACR (uses your Azure CLI identity)
-output "acr_login_command" {
-  description = "Command to login to ACR"
-  value       = "az acr login --name ${azurerm_container_registry.main.name}"
+output "traffic_manager_fqdn" {
+  value = module.traffic_manager.fqdn
 }

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,19 +1,7 @@
-# =============================================================================
-# TERRAFORM VARIABLES - Edit these values!
-# =============================================================================
-
-# Your Azure Subscription ID (from: az account show --query id -o tsv)
-subscription_id = "9c726b7d-61d4-4d41-9f52-6560adc863d9"
-
-# Your app name (lowercase, no special chars)
-app_name = "k8svalidator"
-
-# Environment (dev, staging, prod)
-environment = "dev"
-
-# Azure region - pick one close to you
-# Options: eastus, westus2, westeurope, northeurope, southeastasia, etc.
-location = "eastus"
-
-# Docker image tag
-image_tag = "v1"
+resource_group_name = "rg-dev"
+vnet_name           = "vnet-dev"
+subnet_name         = "subnet-aks"
+acr_name            = "acrdev"
+aks_name            = "aks-dev"
+log_workspace_name  = "log-dev"
+tm_name             = "tm-dev"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,32 +1,32 @@
-# =============================================================================
-# VARIABLES - Input parameters for deployment
-# =============================================================================
-
-variable "subscription_id" {
-  description = "Azure Subscription ID"
-  type        = string
-}
-
-variable "app_name" {
-  description = "Name of the application (used in resource names)"
-  type        = string
-  default     = "k8svalidator"
-}
-
-variable "environment" {
-  description = "Environment name (dev, staging, prod)"
-  type        = string
-  default     = "dev"
-}
-
 variable "location" {
-  description = "Azure region to deploy to"
-  type        = string
-  default     = "eastus"  # Change to your preferred region
+  type    = string
+  default = "East US"
 }
 
-variable "image_tag" {
-  description = "Docker image tag to deploy"
-  type        = string
-  default     = "v1"
+variable "resource_group_name" {
+  type = string
+}
+
+variable "vnet_name" {
+  type = string
+}
+
+variable "subnet_name" {
+  type = string
+}
+
+variable "acr_name" {
+  type = string
+}
+
+variable "aks_name" {
+  type = string
+}
+
+variable "log_workspace_name" {
+  type = string
+}
+
+variable "tm_name" {
+  type = string
 }


### PR DESCRIPTION
### Motivation
- Split the previous monolithic Terraform configuration into reusable modules for better maintainability and reuse. 
- Provide a standard AKS-centric topology that wires Resource Group, VNet/subnet, ACR, AKS, Log Analytics, and Traffic Manager. 
- Ensure ACR naming meets global-uniqueness requirements by sanitizing the base name and appending a random suffix. 
- Expose module outputs at the root to make downstream automation and CI/CD integration easier.

### Description
- Replaced the root `terraform/main.tf` content with module wiring and added the `random` provider to support unique ACR names. 
- Added modules under `terraform/modules/` for `resource_group`, `vnet`, `log_analytics`, `acr`, `aks`, and `traffic_manager`, each with `main.tf`, `variables.tf`, and `outputs.tf` as appropriate. 
- Implemented ACR uniqueness in `terraform/modules/acr` using `random_integer` and a sanitized local name, and added ACR outputs. 
- Updated root `variables.tf`, `terraform.tfvars`, and `outputs.tf` to match the new module inputs/outputs and to surface useful values like `vnet_subnet_id`, `acr_id`, `aks_fqdn`, and `traffic_manager` FQDN.

### Testing
- Attempted `terraform -chdir=terraform fmt -recursive` to run formatting/validation but it failed because the `terraform` CLI is not installed in this environment. 
- Attempted `tofu -chdir=terraform fmt -recursive` as an alternate formatter but it failed because `tofu` is not available in this environment. 
- No automated Terraform validation succeeded in this environment due to the missing CLI, so plan/apply were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699835bd21448324b8b1002161891e0b)