### PR TITLE
Clarify AzureRM backend inputs with concrete backend.hcl file

### DIFF
--- a/terraform/BACKEND.md
+++ b/terraform/BACKEND.md
@@ -1,0 +1,22 @@
+# Terraform Remote Backend (AzureRM)
+
+This repo is configured to use an AzureRM remote backend.
+
+## What you must provide
+Edit `backend.hcl` and set these values from your already-created backend resources:
+
+- `resource_group_name`: resource group that contains the state storage account
+- `storage_account_name`: storage account used for Terraform state
+- `container_name`: blob container for state files
+- `key`: blob name/path for this environment state file (example: `dev/terraform.tfstate`)
+
+## Initialize
+```bash
+terraform init -backend-config=backend.hcl
+```
+
+If Terraform was already initialized with local state, migrate it:
+
+```bash
+terraform init -migrate-state -backend-config=backend.hcl
+```

--- a/terraform/backend.hcl
+++ b/terraform/backend.hcl
@@ -1,0 +1,11 @@
+# Fill these with your ALREADY-CREATED remote state resources.
+# Required values:
+resource_group_name  = "REPLACE_WITH_STATE_RESOURCE_GROUP"
+storage_account_name = "REPLACE_WITH_STATE_STORAGE_ACCOUNT"
+container_name       = "REPLACE_WITH_STATE_CONTAINER"
+key                  = "dev/terraform.tfstate"
+
+# Optional (uncomment if you need explicit auth context)
+# subscription_id     = "00000000-0000-0000-0000-000000000000"
+# tenant_id           = "00000000-0000-0000-0000-000000000000"
+# use_azuread_auth    = true

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "azurerm" {}
+}


### PR DESCRIPTION
### Motivation
- The previous example-only backend file caused confusion about where to put actual backend values, so a concrete file and clear guidance are needed. 

### Description
- Remove the ambiguous `terraform/backend.hcl.example` and add `terraform/backend.hcl` containing placeholder values to be replaced with existing backend resources. 
- Add `terraform/BACKEND.md` with explicit field-by-field guidance and exact `terraform init`/migration commands. 
- Keep `terraform/backend.tf` with an empty `backend "azurerm" {}` block so Terraform reads settings from the `backend.hcl` file at init. 

### Testing
- An attempt to run `terraform -chdir=/workspace/Devops/terraform fmt -check` was made but failed because the Terraform CLI is not installed in this environment. 
- File-level validation confirmed that `backend.hcl` contains the required placeholder fields and that `BACKEND.md` documents the inputs and init/migrate commands. 
- Verified that `backend.tf` contains the `backend "azurerm" {}` block so backend configuration will be read from `backend.hcl` during `terraform init`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69983c541b64832485365e1225cda277)