### PR TITLE
Add env-specific Terraform variable folders for dev/stage/prod

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,21 @@
+# Terraform environments
+
+Environment-specific variable files are organized into dedicated folders:
+
+- `environments/dev/terraform.tfvars`
+- `environments/stage/terraform.tfvars`
+- `environments/prod/terraform.tfvars`
+
+## Usage
+
+Run Terraform with the variable file for the target environment:
+
+```bash
+terraform init
+terraform plan  -var-file=environments/dev/terraform.tfvars
+terraform apply -var-file=environments/dev/terraform.tfvars
+```
+
+Replace `dev` with `stage` or `prod` as needed.
+
+A root `terraform.tfvars` is kept as a default/local fallback (aligned with `dev`).

--- a/terraform/environments/dev/terraform.tfvars
+++ b/terraform/environments/dev/terraform.tfvars
@@ -1,5 +1,3 @@
-# Default/local values (equivalent to dev).
-# Prefer environment-specific files under terraform/environments/<env>/terraform.tfvars.
 location            = "East US"
 resource_group_name = "rg-dev"
 vnet_name           = "vnet-dev"

--- a/terraform/environments/prod/terraform.tfvars
+++ b/terraform/environments/prod/terraform.tfvars
@@ -1,0 +1,8 @@
+location            = "Central US"
+resource_group_name = "rg-prod"
+vnet_name           = "vnet-prod"
+subnet_name         = "subnet-aks"
+acr_name            = "acrprod"
+aks_name            = "aks-prod"
+log_workspace_name  = "log-prod"
+tm_name             = "tm-prod"

--- a/terraform/environments/stage/terraform.tfvars
+++ b/terraform/environments/stage/terraform.tfvars
@@ -1,0 +1,8 @@
+location            = "East US 2"
+resource_group_name = "rg-stage"
+vnet_name           = "vnet-stage"
+subnet_name         = "subnet-aks"
+acr_name            = "acrstage"
+aks_name            = "aks-stage"
+log_workspace_name  = "log-stage"
+tm_name             = "tm-stage"


### PR DESCRIPTION
### Motivation

- Provide clear environment separation for Terraform variable values so deployments can use environment-specific settings (dev, stage, prod).
- Keep a sensible default/local fallback while encouraging use of per-environment `-var-file` for plans and applies.

### Description

- Added `terraform/environments/dev/terraform.tfvars`, `terraform/environments/stage/terraform.tfvars`, and `terraform/environments/prod/terraform.tfvars` with environment-specific values for `location`, `resource_group_name`, `vnet_name`, `subnet_name`, `acr_name`, `aks_name`, `log_workspace_name`, and `tm_name`.
- Created `terraform/README.md` documenting the new environment layout and showing example usage with `terraform plan -var-file=...` and `terraform apply -var-file=...`.
- Updated root `terraform/terraform.tfvars` to act as a default/local fallback aligned to `dev` and added commentary directing users to the environment files.
- No changes were made to existing modules or variable definitions; this change only organizes variable files per environment.

### Testing

- Ran a Terraform formatting check with `terraform fmt -check -recursive`, which could not run because the Terraform CLI is not available in the environment (`terraform: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69985376a8b883248578bc44e2f0b9c2)